### PR TITLE
fix(travis): Make code pass lint and improve the travis configuration.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,36 +1,3 @@
 {
-  'ecmaFeatures': {
-    'modules': true
-  },
-
-  'env': {
-    'browser': true,
-    'es6': true,
-    'node': true
-  },
-
-  'parser': 'babel-eslint',
-
-  'rules': {
-    'eol-last': 2,
-    'max-len': [1, 120, 4],
-    'no-multi-spaces': [1, {
-      'exceptions': {
-        'VariableDeclarator': true,
-        'AssignmentPattern': true,
-        'AssignmentExpression': true
-      }
-    }],
-    'no-underscore-dangle': [0],
-    'no-var': 2,
-    'quotes': [2, 'single'],
-    'space-before-function-paren': [2, {
-      'anonymous': 'always',
-      'named': 'never'
-    }],
-    'strict': [2, 'global']
-  },
-
-  'plugins': [
-  ]
+  'extends': 'rentpath'
 }

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /.aws.martin
 /.aws.rentpathcode
 /.idea
+/.env
 bower_components
 build
 node_modules

--- a/.setpath
+++ b/.setpath
@@ -1,0 +1,2 @@
+export PATH=$(npm bin):$PATH
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,12 +23,9 @@ notifications:
 
 sudo: false
 
-
-#
 # the process
 
 before_install:
-  - npm i -g npm@^2.0.0
   - npm prune
 
 script: npm run test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,37 @@
+branches:
+  except:
+    - "/^v\\d+\\.\\d+\\.\\d+$/"
+
+cache:
+  directories:
+    - node_modules
+
+env:
+  global:
+    - NPM_CONFIG_PROGRESS=false
+    - secure: vJdY0pz/iwQZyEEdAHGxrLtNPtnAgsJf2jIBTCQoSysN0h8TedD+tHlF3JTjnAXJKq9KilOHK7VQRBAKOmPdvWe1bZSRdV/6StR7W+InE7aeFwt3oWmqW5T47S4Irzy3we6r6o0zPd18Bo+ShW0RKBNRmeA4b3qU4tJaqQvljphbhpv7ECaHStgYQoETEVsjqhm/sy82zPOP0nLev0b6zMOVl/CAwQyUyVmCeEv+WKk9u5ZnWqdthb+10H1hwWyRyttSx8+EGEvyj6cZ7zi16IpUB7Mh9jyWw4ggPEKiX5A3qE6+ozbS6+Q9f4bFgux6ko4iTX3JlDmi+7yVWqHdf1HuvKDRux8Elaase9fQdHGVpztBHtSx2HiEXd+CzpkcI+fA3XrAtwbycI/1NXNv1wDwjg888KRCcAmx9RJL8iluemqbyBuodiwBBKmjvjCcPY8f7r8/clpkmOlfRVwb9D8WiYNLVvTCDOHJXdT5i2je7dq4pCVcbiw0Tp0muctbG+1DvnIQMfc+SvlEzM5f/9S+T29CW+Wy9TdWCqm9gkaSTBU9CPjs4YWh2dTLa5WIPNHwZ/9R16y/t5MTUxbDFfzGFZmnDb/swfciYc+hskskd6aoeKxQOsodm3FuyXbCFdgg3CVLcHQLxNqs1FwFZ1EvFZhc16iskXcTvmP/Md0=
+    - secure: XmgohrrmX1jWbGQj/Bs3Imdcj3Y78jBjJwc7eKF+/pLIlLMN+plM53AOmMtbdHzXKz3yoI3WA4bTodFn9jF+O+D5vq1DmAXepxMgbaSQq5w4lD0YvUWS/Tzi3nCIT5pZ+YuX+2KSPHr4YqcLO9sdNiV5IvxD0yyTrQLADcJHdFcrmH47JeHwiYqeJzfr5S0/S7+o8JXdPRjKEqMtbFrb3+PrEEKxmXmtdL2pZuEhZjM0yMyvfuVuj6/d5e+o+MI6fqOgRr+ighCJWGiCOtjpF6+q6IYYFo55//GhZXDCFt4FPMI7ouZWgkhYrqr15I4AAWD+q9X2QLl4Xye7TB5nq4FbAsC0nAuH2U8JMdu8qzfLdJhiWLq9UPniRlRB2YWnZUhvw8Q+8tSsZsC7n+rJu/TSuhl7WLCf1EnfvUltJ/09ftTkkIcKmeY76s7hssS+8H6RxGhv7Mv5f9H+rYfVJ77pf8ef4zl221GfCLMkfDAarvuvHw/nvvwEj0Y+VVoY5HVMStdmMyzHED0LXiSKYVDkn5CKpfx7uyghgTZcdsYJvZWyajJUnRAXllN9NlsO5wJbfrK80cfkee/68qzOSQQ2Tpuhv/WKdDt5lvkLtP88Av6XuKK/NQ9dOnqK09um5iNzNoay/YY4DCbTlQ0909UlzSYJDx6OPSuzTMC8gwg=
+    - secure: agHrVEXJtlE/3vsdo12x6URYQQj2xr9O111hj7PObmiLS4v+OblX9yupccahGidqTEKjifJb40pGxBJf9dIJf/eeTtUbEZvOnP36/WUTipPy8YGMF0VJSh4PtsfYWtQFRfzCeGQOu3yPcKA8KkHoW9hnc7Ta32SRjJsCMoq76Tp7SNvO+wCIhyi8g3ceBYTTB1O1kv5mbsCq3M0eVEqFFrA1ctXEzu71Dw6zL7UpAKOSMy5PpuqvYw61xbUxE+o3Vn+VNErSPAhQ0wo2bj+cMaMrCXs/HN9YcBOPDoNGOJR1JbwVcqiI2EepYvEzrv6MYAhzvXDzZc62S7YY+Pur2jIlKYgXq/PKG0RKT2iYgp3KyYUhyafG2GFR3LysmCJzFZDsquUXjsydRWr3huKYdAd4tJ9ehZNFAfLS8yUJG2MMvWtHfhtjyxiBYyvqgEKy5SCTynLSc2MYW1IpSzypNd+BLQtp0LUkMVcN7LYd39AHR1ekMhmnKuS9BUTMHxf8E4G+Th+tZqMD94WiuvvXyHd6UYfyrCEuynWF9iOJvtI1rCPgmQyy17KwJGXy8wDnICquteBV6iMM76tAOTsLVB3MF3mKw0JrTdK4T2bqPa7WMNp4pTs1cHLMJyDB/NTIyniLdufmzC3/wMmh1maFlLJp/6PFO8lgrBzoASRwkqI=
+
 language: node_js
 
 node_js:
-  - "4.1"
+  - '5.6'
 
-before_script:
-  - npm install
+notifications:
+  email: false
+
+sudo: false
+
+
+#
+# the process
+
+before_install:
+  - npm i -g npm@^2.0.0
+  - npm prune
+
+script: npm run test
+
+after_success:
+  - test $TRAVIS_PULL_REQUEST == "false" && test $TRAVIS_BRANCH == "master" && npm run release

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Automated tests poke and prod the entry points to the library. _Karma_ is the te
 The default test runner executes the tests only once, which is ideal for CI (_Travis_ and such).
 
 ```
-$ npm test
+$ npm run test
 ```
 
 This will auto watch all files for changes and rerun the tests. Ideal for development.

--- a/package.json
+++ b/package.json
@@ -1,14 +1,16 @@
 {
   "name": "identity",
-  "version": "1.2.2",
+  "version": "0.0.0-semantically-released",
   "description": "Allocate and track a universal Rentpath ID using the Personalization service as a backend.",
   "main": "identity.js",
   "scripts": {
+    "build": "webpack --config webpack.config.production.js",
+    "deploy": "node deploy.js",
+    "lint": "eslint src tests",
+    "release": "semantic-release pre && npm publish && semantic-release post",
     "start": "node server.js",
-    "build": "./node_modules/.bin/webpack --config webpack.config.production.js",
-    "test": "./node_modules/karma/bin/karma start --single-run --no-auto-watch karma.config.js",
-    "test_watch": "./node_modules/karma/bin/karma start --auto-watch --no-single-run karma.config.js",
-    "lint": "./node_modules/.bin/eslint ."
+    "test": "karma start --single-run --no-auto-watch karma.config.js",
+    "test_watch": "karma start --auto-watch --no-single-run karma.config.js"
   },
   "repository": {
     "type": "git",
@@ -31,16 +33,19 @@
     "js-cookie": "^2.0.4"
   },
   "devDependencies": {
+    "babel": "5.8.29",
     "babel-core": "^5.4.5",
     "babel-eslint": "^3.1.6",
     "babel-loader": "^5.0.0",
     "commitizen": "2.4.6",
     "compression-webpack-plugin": "0.2.0",
-    "conventional-changelog": "0.5.3",
-    "eslint": "^0.21.2",
-    "eslint-plugin-react": "^2.3.0",
-    "file":"0.2.2",
+    "conventional-changelog": ">=1.0.0",
+    "eslint": "^1.10.3",
+    "eslint-config-rentpath": "^1.2.0",
+    "eslint-plugin-react": "^3.16.1",
+    "file": "0.2.2",
     "ghooks": "1.0.1",
+    "graceful-fs": ">=4.0.0",
     "istanbul-instrumenter-loader": "^0.1.3",
     "jasmine-core": "^2.3.4",
     "karma": "^0.13.3",
@@ -51,6 +56,7 @@
     "karma-sourcemap-loader": "~0.3",
     "karma-spec-reporter": "0.0.20",
     "karma-webpack": "^1.7.0",
+    "lodash": "^4.0.0",
     "phantomjs": "^1.9.17",
     "phantomjs-polyfill": "0.0.1",
     "s3-cli": "0.13.0",

--- a/src/index.js
+++ b/src/index.js
@@ -1,1 +1,1 @@
-import Identity from './identity';
+import Identity from './identity'

--- a/src/request.js
+++ b/src/request.js
@@ -1,68 +1,67 @@
 class Request {
   constructor(
     successFn,
-    failureFn = () => {},
-    host      = 'http://identity.rentpathservices.com',
-    port      = 80,
-    target    = '/universal_zids/new',
-    method    = 'GET',
-    retries   = 3,
-    timeout   = 500,
-    timeoutFn)
-  {
-    this.failureFn  = failureFn;
-    this.host       = host;
-    this.method     = method;
-    this.port       = port;
-    this.request    = new XMLHttpRequest();
-    this.retries    = retries;
-    this.successFn  = successFn;
-    this.target     = target;
-    this.timeout    = timeout;
-    this.timeoutFn  = timeoutFn;
+    failureFn = () => { /* nop */ },
+    host = 'http://identity.rentpathservices.com',
+    port = 80,
+    target = '/universal_zids/new',
+    method = 'GET',
+    retries = 3,
+    timeout = 500,
+    timeoutFn
+  ) {
+    this.failureFn = failureFn
+    this.host = host
+    this.method = method
+    this.port = port
+    this.request = new XMLHttpRequest()
+    this.retries = retries
+    this.successFn = successFn
+    this.target = target
+    this.timeout = timeout
+    this.timeoutFn = timeoutFn
 
-    const hostname  = this.host.replace(/\/$/, '');
-    const path      = this.target.replace(/^\//, '');
-    const repeat    = this.retry;
-    const url       = `${hostname}:${port}/${path}`;
+    const hostname = this.host.replace(/\/$/, '')
+    const path = this.target.replace(/^\//, '')
+    const repeat = this.retry.bind(this)
+    const url = `${hostname}:${port}/${path}`
 
-    this.request.open(method, url, true);
-    this.request.setRequestHeader('Accept', 'application/json');
-    this.request.setRequestHeader('Content-Type', 'application/json');
+    this.request.open(method, url, true)
+    this.request.setRequestHeader('Accept', 'application/json')
+    this.request.setRequestHeader('Content-Type', 'application/json')
 
-    this.request.onload = function () {
+    this.request.onload = function() {
       if (this.status >= 200 && this.status < 400) {
-        const data = JSON.parse(this.responseText);
-        successFn.call(data);
+        const data = JSON.parse(this.responseText)
+        successFn.call(data)
       } else {
-        failureFn(this.status, this.responseText);
+        failureFn(this.status, this.responseText)
       }
-    };
+    }
 
-    this.request.onerror = function () {
+    this.request.onerror = function() {
       if (this.readyState === 4 && this.status === 0) {
-        failureFn('NO_NETWORK');
+        failureFn('NO_NETWORK')
       } else {
-        failureFn(this.status, this.responseText);
+        failureFn(this.status, this.responseText)
       }
-    };
+    }
 
-    this.request.ontimeout = function () {
+    this.request.ontimeout = function() {
       if (timeoutFn) {
-        timeoutFn();
-        return;
+        timeoutFn()
+        return
       }
 
       if (retries > 0) {
-        repeat().send();
+        repeat().send()
       } else {
-        this.onerror('timeout');
+        this.onerror('timeout')
       }
-    };
+    }
   }
 
-  retry = () =>
-  {
+  retry() {
     return new Request(
       this.successFn,
       this.failureFn,
@@ -72,15 +71,14 @@ class Request {
       this.method,
       this.retries - 1,
       this.timeout,
-      this.timeoutFn);
+      this.timeoutFn)
   }
 
-  send = () =>
-  {
-    this.request.withCredentials = true;
-    this.request.timeout         = this.timeout;
-    this.request.send();
+  send() {
+    this.request.withCredentials = true
+    this.request.timeout = this.timeout
+    this.request.send()
   }
 }
 
-export default Request;
+export default Request


### PR DESCRIPTION
@colinrymer @Teapane This is ready for a review. This should get us to the point where a semantic release is sent to npm. It does not yet deploy to S3.

Some questions:

The latest release was 1.2.2. Can we make the first release to npm 1.3.0 since the current code has a new feature in it. How do we set the baseline version number for semantic-release to use?

Once a release to npm occurs, I can likely find the version number of that release and use those numbers to perform the release to S3. Previously, the version number came from package.json as it was a literal string. With semantic-release, there is a placeholder and the ultimate version number is left in npm. I'll take those numbers and a modified deploy.js script and push to S3. OK?